### PR TITLE
Adjusted the log message so that the payload is displayed in text format

### DIFF
--- a/labs/Lab2.md
+++ b/labs/Lab2.md
@@ -137,7 +137,7 @@ Add the follwoing code just after you successfully connected to the IoT Hub.
 ```js
 client.on('message', function (msg) {
     console.log('Received Command: WARNING');
-    console.log(JSON.stringify(msg));
+    console.log(String.fromCharCode.apply(null, msg.data));
 });
 ```
 


### PR DESCRIPTION
After the change we show a human understandable message rather than the brokered message with binary data.

Example result (after the fix):

{"acState":"Off"}